### PR TITLE
Add generic VCP downloads link and URL to v4.5

### DIFF
--- a/docs/task_vcp_upgrade_plugin.adoc
+++ b/docs/task_vcp_upgrade_plugin.adoc
@@ -24,7 +24,7 @@ This upgrade procedure covers the following upgrade scenarios:
 * You are upgrading to a 7.0, 6.7, or 6.5 HTML5 vSphere Web Client.
 * You are upgrading to a 6.7 or 6.5 Flash vSphere Web Client.
 
-IMPORTANT: The plug-in is compatible with vSphere Web Client version 6.7 U2 for Flash and with version 6.7 U3 (Flash and HTML5). The plug-in is not compatible with version 6.7 U2 of the HTML5 vSphere Web Client. For more information about all supported vSphere versions, see the https://library.netapp.com/ecm/ecm_download_file/ECMLP2866569[release notes] for the plug-in.
+IMPORTANT: The plug-in v4.4 is compatible with vSphere Web Client version 6.7 U2 for Flash and with version 6.7 U3 (Flash and HTML5). The plug-in is not compatible with version 6.7 U2 of the HTML5 vSphere Web Client. For more information about all supported vSphere versions, see the release notes of the version that interests you (check out all https://mysupport.netapp.com/documentation/productlibrary/index.html?productID=62701[NetApp Element Plug-In downloads] or directly access the release notes document for version https://library.netapp.com/ecm/ecm_download_file/ECMLP2866569[4.4] or https://library.netapp.com/ecm/ecm_get_file/ECMLP2873396[4.5]).
 
 .What you'll need
 


### PR DESCRIPTION
The RN link was for v4.4 and a link to RN for v4.5 was missing.
Additionally, the IMT still not have v4.5 in it, so it's better to have this updated and add a more generic link so that we don't have to update this page again.
Feel free to edit my PR as you wish.