### PR TITLE
Mw doc 3316 trident link hotfix

### DIFF
--- a/docs/task_rancher_trident.adoc
+++ b/docs/task_rancher_trident.adoc
@@ -21,6 +21,7 @@ TIP: For more information about Trident, see the https://netapp-trident.readthed
 
 * You have installed Rancher on NetApp HCI.
 * You have deployed your user clusters.
+* You have configured your user cluster networks for Trident. See link:task_trident_configure_networking.html[Enable Trident support for user clusters^] for instructions.
 * You have completed the necessary prerequisite steps for work node preparation for Trident. See the https://netapp-trident.readthedocs.io/en/stable-v20.10/kubernetes/operations/tasks/worker.html[Trident documentation].
 
 .About this task


### PR DESCRIPTION
Added link to Trident network config for user clusters to Trident install topic's list of prereqs.