### PR TITLE
Yos oct fw updates - added details for Element 12.7 and SFB 2.164.0. 

### DIFF
--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,7 +19,7 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
-* <<sf_nodes, SF38410, SF19210, SF9605, and SF4805>
+* <<sf_nodes, SF38410, SF19210, SF9605, and SF4805>>
 
 == H610S
 *Model Number (Family portion):* H610S

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -776,7 +776,7 @@ h| *Storage Firmware Bundle 2.164.0*
 | 10/20/2022
 | NAT3.4 
 | 6.98.00
-| 7.10.18	
+| 14.25.1020	
 | ae3b8cc	
 | 7d8422bc	
 | GXT5404Q	
@@ -788,7 +788,7 @@ h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
 | 10/20/2022
 | NAT3.4 
 | 6.98.00
-| 7.10.18	
+| 14.25.1020	
 | ae3b8cc	
 | 7d8422bc	
 | GXT5404Q	

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,7 +19,7 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
-* <<sf_nodes,SF38410, SF19210, SF9605, and SF4805>
+* <<sf_nodes, SF38410, SF19210, SF9605, and SF4805>
 
 == H610S
 *Model Number (Family portion):* H610S
@@ -1006,7 +1006,7 @@ The following firmware is not managed by a Storage Firmware Bundle:
 | Boot Device MTFDDAV240TCB1AR | DOMU037
 |===
 
-== [[sf_nodes]]SF38410 / SF19210 / SF9605 / SF4805
+== [[sf_nodes]]SF38410, SF19210, SF9605, and SF4805
 
 *Full Model Numbers:* H410S-0, H410S-1, H410S-1-NE, and H410S-2
 

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -39,7 +39,8 @@ h| Release Date
 h| BIOS
 h| BMC
 h| CPLD
-h| 10/25 GbE NIC Quanta Mellanox
+h| 10/25 GbE NIC CX4
+h| 10/25 GbE NIC CX5
 h| Cache NVDIMM NVDIMM module Smart (Gen1)
 h| Cache NVDIMM Energy Source (BPM) Smart (Gen1)
 h| Cache NVDIMM NVDIMM module Smart (Gen2)
@@ -59,12 +60,65 @@ h| Drive CD5 (FIPS)
 h| Drive Samsung PM9A3 (SED)
 h| Drive SK Hynix PE8010 (SED)
 h| Drive SK Hynix PE8010 (N-SED)
+h| *Storage Firmware Bundle 2.164.0*
+| 10/20/2022
+| 3B11	
+| 3.94.07	
+| 122	
+| 14.25.1020	 
+| 16.32.1010	
+| 3.1
+| 2.16
+| 26.2C
+| 1.30
+| 25.3C	
+| 1.40	
+| 1.10	
+| 3.3	
+| 2.16	
+| CXV8202Q	
+| CXV8501Q	
+| EDA5602Q	
+| EDA5900Q	
+| 0109	
+| 0109	
+| 0108	
+| GDC5602Q	
+| 11092A10	
+| 110B2A10
+h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
+| 10/20/2022
+| 3B11	
+| 3.94.07	
+| 122	
+| 14.25.1020	 
+| 16.32.1010	
+| 3.1
+| 2.16
+| 26.2C
+| 1.30
+| 25.3C	
+| 1.40	
+| 1.10	
+| 3.3	
+| 2.16	
+| CXV8202Q	
+| CXV8501Q	
+| EDA5602Q	
+| EDA5900Q	
+| 0109	
+| 0109	
+| 0108	
+| GDC5602Q	
+| 11092A10	
+| 110B2A10
 h| *Storage Firmware Bundle 2.150.4*
 | 06/08/2022
 | 3B11
 | 3.94.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -90,6 +144,7 @@ h| *Storage Firmware Bundle 2.150.4 through NetApp Element 12.5*
 | 3.94.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -115,6 +170,7 @@ h| *Storage Firmware Bundle 2.146.2*
 | 3.94.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -140,6 +196,7 @@ h| *Storage Firmware Bundle 2.99.4 through NetApp Element 12.3.2*
 | 3.91.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -165,6 +222,7 @@ h| *Storage Firmware Bundle 2.99.4 through NetApp Element 12.3.1.165*
 | 3.91.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -190,6 +248,7 @@ h| *Storage Firmware Bundle 2.99.2*
 | 3.91.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -215,6 +274,7 @@ h| *Storage Firmware Bundle 2.99.1 through NetApp Element 12.3.1.103*
 | 3.86.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -240,6 +300,7 @@ h| *Storage Firmware Bundle 2.99 through NetApp Element 12.3*
 | 3.86.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -265,6 +326,7 @@ h| *Storage Firmware Bundle 2.76.8*
 | 3.86.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -290,6 +352,7 @@ h| *Storage Firmware Bundle 2.27.1*
 | 3.84.07
 | 122
 | 14.02.1002
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -315,6 +378,7 @@ h| *Storage Firmware Bundle 2.76.8 through NetApp Element 12.2.1*
 | 3.86.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -340,6 +404,7 @@ h| *Storage Firmware Bundle 2.21 through NetApp Element 12.2*
 | 3.84.07
 | 122
 | 14.22.1002
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -365,6 +430,7 @@ h| *Storage Firmware Bundle 2.76.8 through NetApp Element 12.0.1*
 | 3.86.07
 | 122
 | 14.25.1020
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -390,6 +456,7 @@ h| *Storage Firmware Bundle 1.2.17 through NetApp Element 12.0*
 | 3.78.07
 | 122
 | 14.22.1002
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -415,6 +482,7 @@ h| *NetApp Element 11.8*
 | 3.78.07
 | 122
 | 14.22.1002
+| -
 | 3.1
 | 2.16
 | 26.2C
@@ -440,6 +508,7 @@ h| *NetApp Element 11.7*
 | 3.76.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -465,6 +534,7 @@ h| *NetApp Element 11.5.1*
 | 3.76.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -490,6 +560,7 @@ h| *NetApp Element 11.5*
 | 3.76.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -515,6 +586,7 @@ h| *NetApp Element 11.3.2*
 | 3.76.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -540,6 +612,7 @@ h| *NetApp Element 11.3.1*
 | 3.76.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -565,6 +638,7 @@ h| *NetApp Element 11.1.1*
 | 3.70.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -590,6 +664,7 @@ h| *NetApp Element 11.1*
 | 3.70.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -615,6 +690,7 @@ h| *NetApp Element 11.0.2*
 | 3.70.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -640,6 +716,7 @@ h| *NetApp Element 11*
 | 3.70.07
 | 117
 | 14.22.1002
+| -
 | 2.C
 | 2.07
 | 26.2C
@@ -695,18 +772,26 @@ h| Drive Samsung PM863 (N-SED)
 h| Drive Toshiba Hawk-4 (SED)
 h| Drive Toshiba Hawk-4 (N-SED)
 h| Drive Samsung PM883 (SED)
-h| *Storage Firmware Bundle 1.2.17 through NetApp Element 12.0*
-| 03/20/2020
-| NA2.1
-| 3.25
-| 14.21.1000
-| ae3b8cc
-| 7d8422bc
-| GXT5404Q
-| GXT5103Q
-| 8ENP7101
-| 8ENP6101
-| HXT7104Q
+h| *Storage Firmware Bundle 2.164.0*
+| 10/20/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
+h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
+| 10/20/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
 h| *Storage Firmware Bundle 2.150.4 through NetApp Element 12.5*
 | 06/08/2022
 | NAT3.4
@@ -743,7 +828,7 @@ h| *Storage Firmware Bundle 2.76.8 through NetApp Element 12.2.1*
 | 8ENP7101
 | 8ENP6101
 | HXT7904Q
-h| *SFB 1.2.17 through NetApp Element 12.0*
+h| *Storage Firmware Bundle 1.2.17 through NetApp Element 12.0*
 | 03/20/2020
 | NA2.1
 | 3.25

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -774,6 +774,8 @@ h| Drive Toshiba Hawk-4 (N-SED)
 h| Drive Samsung PM883 (SED)
 h| *Storage Firmware Bundle 2.164.0*
 | 10/20/2022
+| NAT3.4 
+| 6.98.00
 | 7.10.18	
 | ae3b8cc	
 | 7d8422bc	
@@ -782,10 +784,10 @@ h| *Storage Firmware Bundle 2.164.0*
 | 8ENP7101	
 | 8ENP6101	
 | HXT7A04Q
-| -
-| -
 h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
 | 10/20/2022
+| NAT3.4 
+| 6.98.00
 | 7.10.18	
 | ae3b8cc	
 | 7d8422bc	
@@ -794,8 +796,6 @@ h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
 | 8ENP7101	
 | 8ENP6101	
 | HXT7A04Q
-| -
-| -
 h| *Storage Firmware Bundle 2.150.4 through NetApp Element 12.5*
 | 06/08/2022
 | NAT3.4

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,6 +19,7 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
+* <<SF38410 SF19210 SF9605 SF4805>>
 
 == H610S
 //*ODM:* Quanta
@@ -1036,4 +1037,323 @@ The following firmware is not managed by a Storage Firmware Bundle:
 | Power Supply	| 1.3
 | Boot Device SSDSCKJB240G7 | N2010121
 | Boot Device MTFDDAV240TCB1AR | DOMU037
+|===
+
+== SF38410 SF19210 SF9605 SF4805
+
+*Full Model Numbers:* H410S-0, H410S-1, H410S-1-NE, and H410S-2
+
+=== Component firmware managed by a Storage Firmware Bundle
+During 11.x timeframe, NetApp Element software was the only way to release firmware. Starting with Element 12.0, the concept of a *Storage Firmware Bundle* was introduced and firmware updates were now possible by an independently released Storage Firmware Bundle or Storage Firmware Bundle included as part of a 12.x Element release.
+
+NOTE: A dash (*-*) in the following table indicates that the particular hardware component was NOT supported in that given release vehicle.
+
+
+[cols=10*,options="header"]
+|===
+h| Release Vehicle
+h| Release Date
+H| NIC
+h| Cache NVDIMM RMS200 (RMS200)
+h| Cache NVDIMM RMS200 (RMS300)
+h| Drive Samsung PM863 (SED)
+h| Drive Samsung PM863 (N-SED)
+h| Drive Toshiba Hawk-4 (SED)
+h| Drive Toshiba Hawk-4 (N-SED)
+h| Drive Samsung PM883 (SED)
+h| *Storage Firmware Bundle 2.164.0*
+h| 10/20/2022
+h| 7.10.18	
+h| ae3b8cc	
+h| 7d8422bc	
+h| GXT5404Q	
+h| GXT5103Q	
+h| 8ENP7101	
+h| 8ENP6101	
+h| HXT7A04Q
+h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
+h| 10/20/2022
+h| 7.10.18	
+h| ae3b8cc	
+h| 7d8422bc	
+h| GXT5404Q	
+h| GXT5103Q	
+h| 8ENP7101	
+h| 8ENP6101	
+h| HXT7A04Q
+h| *Storage Firmware Bundle 2.150.4*
+| 06/08/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
+h| *Storage Firmware Bundle 2.150.4 through NetApp Element 12.5*
+| 06/08/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
+h| *Storage Firmware Bundle 2.146.2*
+| 02/22/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
+h| *Storage Firmware Bundle 2.99.4 through NetApp Element 12.3.2*
+| 09/16/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.99.4 through NetApp Element 12.3.1.165*
+| 12/06/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.99.2*
+| 08/03/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.99.1 through NetApp Element 12.3.1.103*
+| 09/16/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.99 through NetApp Element 12.3*
+| 04/15/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.76.8*
+| 02/03/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.27.1*
+| 09/29/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *Storage Firmware Bundle 2.76.8 through NetApp Element 12.2.1*
+| 06/02/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 2.21 through NetApp Element 12.2*
+| 09/29/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *Storage Firmware Bundle 2.76.8 through NetApp Element 12.0.1*
+| 06/02/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7904Q
+h| *Storage Firmware Bundle 1.2.17 through NetApp Element 12.0*
+| 03/20/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.8.2*
+| 02/22/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.8.1*
+| 06/02/2021
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.8*
+| 03/11/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.7*
+| 11/21/2019
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.5.1*
+| 02/19/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.5*
+| 09/26/2019
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.3.2*
+| 02/19/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.3.1*
+| 08/19/2019
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.1.1*
+| 02/19/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.1*
+| 04/25/2019
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11.0.2*
+| 02/19/2020
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+h| *NetApp Element 11*
+| 11/29/2018
+| 7.10.18	
+| ae3b8cc
+| -	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7104Q
+|===
+
+=== Component firmware not managed by a Storage Firmware Bundle
+
+The following firmware is not managed by a Storage Firmware Bundle:
+
+[cols=2*,options="header"]
+|===
+| Component | Current version
+| BIOS	| 2.8.0
+| iDRAC	| 2.75.75.75
+| Identity Module | N41WC 1.02
+| SAS Adapter | 16.00.01.00
+| Power Supply	| 1.3
+| Boot Device | M161225i
 |===

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,78 +19,12 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
-* <<SF38410 SF19210 SF9605 SF4805>>
+* <<SF38410, SF19210, SF9605, and SF4805>>
 
 == H610S
-//*ODM:* Quanta
-//*Platform:* QS52B-1Ud
-//*Model Number (Family portion):* H610S
-//*Full Model Numbers:* H610S-1, H610S-1-NE, H610S-2, H610S-2-NE, H610S-4, H610S-4-NE, H610S-2F
-//==== Vendor/Part number for all components
 *Model Number (Family portion):* H610S
 *Full Model Numbers:* H610S-1, H610S-1-NE, H610S-2, H610S-2-NE, H610S-4, H610S-4-NE, and H610S-2F
 
-//[cols=3*,options="header"]
-//|===
-//| Component
-//| Vendor
-//| Part number
-//| BIOS
-//| Quanta
-//| Motherboard
-//| BMC
-//| Quanta
-//| Motherboard
-//| CPLD
-//| Quanta
-//| Motherboard
-//| 1/10 GbE NIC
-//| Quanta/Intel
-//| 3GS5BMA00D0
-//| 10/25 GbE NIC
-//| Mellanox
-//| MCX4121A-ACAT
-//.2+a| NVDIMM Module
-//.2+a| Smart
-//| STN722G4QNT26MP1SC (Gen 2)
-//NVDIMM Module #4
-//| SH2047NJ420472SB3 (Gen 1)
-//NVDIMM Module #1
-//.2+a| Energy Source (BPM)
-//.2+a| Smart
-//| STC48042QNTDE82BVG (Gen 2)
-//Energy Source #5
-//| SSC48042SMTDE82B (Gen 1)
-//Energy Source #1
-//.2+a| NVDIMM Module
-//.2+a| Micron
-//| 18ASF2G72PF12G9WP1AB (Gen 2)
-// NVDIMM Module #3
-//| 18ASF2G72PF12G6V21AB (Gen 1)
-//NVDIMM Module #2
-//.3+a| Energy Source (PGEM)
-//.3+a| Micron/Agigatech
-//| AGIGA9834-203JCA (Gen 3)
-// Energy Source #4
-//| AGIGA9824-103JCB (Gen 2)
-//Energy Source #3
-//| AGIGA9824-103JCA (Gen 1)
-//Energy Source #2
-//| Boot Device
-//| Innodisk
-//| 3GM2-P
-//.3+a| Drives
-//.3+a| Samsung
-//| PM9A3
-//| PM983
-//| PM963
-//| Drives
-//| Kioxia
-//| CD5
-//| Drives
-//| Solidigm (SK Hynix)
-//| PE8010
-//|===
 
 === Component firmware managed by a Storage Firmware Bundle
 During 11.x timeframe, NetApp Element software was the only way to release firmware. Starting with Element 12.0, the concept of a *Storage Firmware Bundle* was introduced and firmware updates were now possible by an independently released Storage Firmware Bundle or Storage Firmware Bundle included as part of a 12.x Element release.
@@ -740,64 +674,8 @@ The following firmware is not managed by a Storage Firmware Bundle:
 |===
 
 == H410S
-//*ODM:* SuperMicro (MSC)
-//*Platform:* BigTwin X10 - Broadwell
-//==== Vendor/Part number for all components
 *Model Number (Family portion):* H410S
 *Full Model Numbers:* H410S-0, H410S-1, H410S-1-NE, and H410S-2
-
-//[cols=3*,options="header"]
-//|===
-//| Component
-//| Vendor
-//| Part number
-//| BIOS
-//| SMCI
-//| Motherboard
-//| BMC
-//| SMCI
-//| Motherboard
-//| CPLD
-//| SMCI
-//| Motherboard
-//| SAS Adapter
-//| SMCI/Broadcom
-//| BPN-6S3008N4-1UB-NA11
-//| MicroController Unit (MCU)
-//| SMCI
-//| BPN-SAS3-217BHQ-N4-NA11
-//| SIOM 1/10 GbE NIC
-//| SMCI/Intel
-//| AOC-MH25G-M2S2TM-NA011
-//| SIOM 10/25 GbE NIC
-//| SMCI/Mellanox
-//| AOC-MH25G-M2S2TM-NA011
-//| AOC 10/25 GbE NIC
-//| SMCI/Mellanox
-//| AOC-S25G-M2S-NA011
-//| Cache NVDIMM
-//| Radian
-//| RMS-200
-//| Cache NVDIMM
-//| Radian
-//| RMS-300
-//| Power Supply
-//| SMCI
-//| PWS-2K22A-1R-NA011
-//| Boot Device
-//| Intel
-//| SSDSCKJB240G7
-//| Boot Device
-//| Micron
-//| MTFDDAV240TCB1AR
-//.2+a| Drives
-//.2+a| Samsung
-//| PM883
-//| PM863
-//| Drives
-//| Toshiba
-//| Hawk-4
-//|===
 
 === Component firmware managed by a Storage Firmware Bundle
 
@@ -1039,7 +917,7 @@ The following firmware is not managed by a Storage Firmware Bundle:
 | Boot Device MTFDDAV240TCB1AR | DOMU037
 |===
 
-== SF38410 SF19210 SF9605 SF4805
+== SF38410, SF19210, SF9605, and SF4805
 
 *Full Model Numbers:* H410S-0, H410S-1, H410S-1-NE, and H410S-2
 
@@ -1048,12 +926,11 @@ During 11.x timeframe, NetApp Element software was the only way to release firmw
 
 NOTE: A dash (*-*) in the following table indicates that the particular hardware component was NOT supported in that given release vehicle.
 
-
 [cols=10*,options="header"]
 |===
 h| Release Vehicle
 h| Release Date
-H| NIC
+h| NIC
 h| Cache NVDIMM RMS200 (RMS200)
 h| Cache NVDIMM RMS200 (RMS300)
 h| Drive Samsung PM863 (SED)
@@ -1062,25 +939,25 @@ h| Drive Toshiba Hawk-4 (SED)
 h| Drive Toshiba Hawk-4 (N-SED)
 h| Drive Samsung PM883 (SED)
 h| *Storage Firmware Bundle 2.164.0*
-h| 10/20/2022
-h| 7.10.18	
-h| ae3b8cc	
-h| 7d8422bc	
-h| GXT5404Q	
-h| GXT5103Q	
-h| 8ENP7101	
-h| 8ENP6101	
-h| HXT7A04Q
+| 10/20/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
 h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
-h| 10/20/2022
-h| 7.10.18	
-h| ae3b8cc	
-h| 7d8422bc	
-h| GXT5404Q	
-h| GXT5103Q	
-h| 8ENP7101	
-h| 8ENP6101	
-h| HXT7A04Q
+| 10/20/2022
+| 7.10.18	
+| ae3b8cc	
+| 7d8422bc	
+| GXT5404Q	
+| GXT5103Q	
+| 8ENP7101	
+| 8ENP6101	
+| HXT7A04Q
 h| *Storage Firmware Bundle 2.150.4*
 | 06/08/2022
 | 7.10.18	

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,7 +19,7 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
-* <<SF38410 / SF19210 / SF9605 / SF4805>>
+* <<sf_nodes,SF38410, SF19210, SF9605, and SF4805>
 
 == H610S
 *Model Number (Family portion):* H610S
@@ -1006,7 +1006,7 @@ The following firmware is not managed by a Storage Firmware Bundle:
 | Boot Device MTFDDAV240TCB1AR | DOMU037
 |===
 
-== SF38410 / SF19210 / SF9605 / SF4805
+== [[sf_nodes]]SF38410 / SF19210 / SF9605 / SF4805
 
 *Full Model Numbers:* H410S-0, H410S-1, H410S-1-NE, and H410S-2
 

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,7 +19,7 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
-* <<SF38410 SF19210, SF9605, and SF4805>>
+* <<SF38410 / SF19210 / SF9605 / SF4805>>
 
 == H610S
 *Model Number (Family portion):* H610S
@@ -917,7 +917,7 @@ The following firmware is not managed by a Storage Firmware Bundle:
 | Boot Device MTFDDAV240TCB1AR | DOMU037
 |===
 
-== SF38410, SF19210, SF9605, and SF4805
+== SF38410 / SF19210 / SF9605 / SF4805
 
 *Full Model Numbers:* H410S-0, H410S-1, H410S-1-NE, and H410S-2
 

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -19,7 +19,7 @@ summary: Supported firmware and driver versions for storage nodes.
 == Storage nodes
 * <<H610S>>
 * <<H410S>>
-* <<SF38410, SF19210, SF9605, and SF4805>>
+* <<SF38410 SF19210, SF9605, and SF4805>>
 
 == H610S
 *Model Number (Family portion):* H610S

--- a/docs/fw_storage_nodes.adoc
+++ b/docs/fw_storage_nodes.adoc
@@ -32,7 +32,7 @@ During 11.x timeframe, NetApp Element software was the only way to release firmw
 NOTE: A dash (*-*) in the following table indicates that the particular hardware component was NOT supported in that given release vehicle.
 
 
-[cols=25*,options="header"]
+[cols=26*,options="header"]
 |===
 h| Release Vehicle
 h| Release Date
@@ -782,6 +782,8 @@ h| *Storage Firmware Bundle 2.164.0*
 | 8ENP7101	
 | 8ENP6101	
 | HXT7A04Q
+| -
+| -
 h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
 | 10/20/2022
 | 7.10.18	
@@ -792,6 +794,8 @@ h| *Storage Firmware Bundle 2.164.0 through NetApp Element 12.7*
 | 8ENP7101	
 | 8ENP6101	
 | HXT7A04Q
+| -
+| -
 h| *Storage Firmware Bundle 2.150.4 through NetApp Element 12.5*
 | 06/08/2022
 | NAT3.4


### PR DESCRIPTION
Also added table for SF nodes SF38410, SF19210, SF9605, and SF4805.